### PR TITLE
Fix provider crashes when calling `getInit` on a non-contract address.

### DIFF
--- a/core/inpage/contract.ts
+++ b/core/inpage/contract.ts
@@ -117,14 +117,16 @@ export class Contract {
     return result;
   }
 
-  public async getInit(): Promise<object[]> {
+  public async getInit(): Promise<object[] | undefined> {
     assert(Boolean(this.address), `this.address ${ErrorMessages.RequiredParam}`);
 
     const { RPCMethod } = this.transaction.provider;
-    const { result, error } = await this.transaction.provider.send(
+    const response = await this.transaction.provider.send(
       RPCMethod.GetSmartContractInit,
       this.contractAddress
     );
+
+    if (!response) return undefined;
 
     if (error) {
       throw new Error(String(error));


### PR DESCRIPTION
Reproduction Steps:
```
zilPay.contracts.at("0x5454de40eb75020deba6a57fc6e258577cf35858").getInit();
```
`0x5454de40eb75020deba6a57fc6e258577cf35858` is an externally owned address. Calling `getInit` on any non-contract address will result in this uncaught error.

This fix returns `undefined` if `getInit` is called on a non-contract address. Imitates the behaviour of [Zilliqa JS SDK](https://github.com/Zilliqa/Zilliqa-JavaScript-Library/blob/69a4eb713945b5fb691e5a18c30a6e23eb66ca27/packages/zilliqa-js-contract/src/contract.ts#L394)

![Screenshot 2022-01-26 at 3 16 55 PM](https://user-images.githubusercontent.com/6249166/151119544-b4260715-7ff5-40c7-b0f6-140245d8e1e2.png)

Edit: Although this issue is fundamentally with the `transaction.provider`, it should not be returning `undefined` for `response`.